### PR TITLE
Extract vhost-user-backend patches from cloud hypervisor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "vhost_user_backend"
+version = "0.1.0"
+authors = ["The Cloud Hypervisor Authors"]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+epoll = ">=4.0.1"
+libc = ">=0.2.39"
+log = ">=0.4.6"
+virtio-bindings = "0.1.0"
+vm-memory = {version = ">=0.2.0", features = ["backend-mmap"]}
+vm-virtio = { git = "https://github.com/cloud-hypervisor/vm-virtio", branch = "dragonball" }
+vmm-sys-util = ">=0.3.1"
+vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,6 +329,12 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
                         .map_err(VringEpollHandlerError::HandleEventReadKick)?;
                 }
 
+                // If the vring is not enabled, it should not be processed.
+                // The event is only read to be discarded.
+                if !self.vrings[device_event as usize].read().unwrap().enabled {
+                    return Ok(false);
+                }
+
                 self.process_queue(device_event)?;
                 Ok(false)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,7 +573,7 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
     }
 
     fn set_features(&mut self, features: u64) -> VhostUserResult<()> {
-        if !self.owned || self.features_acked {
+        if !self.owned {
             return Err(VhostUserError::InvalidOperation);
         } else if (features & !self.backend.read().unwrap().features()) != 0 {
             return Err(VhostUserError::InvalidParam);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,9 +153,10 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
     /// terminate.
     pub fn wait(&mut self) -> Result<()> {
         if let Some(handle) = self.main_thread.take() {
-            let _ = handle.join().map_err(Error::WaitDaemon)?;
+            handle.join().map_err(Error::WaitDaemon)?
+        } else {
+            Ok(())
         }
-        Ok(())
     }
 
     /// Retrieve the vring worker. This is necessary to perform further

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ use vhost_rs::vhost_user::{
     Error as VhostUserError, Result as VhostUserResult, SlaveFsCacheReq, SlaveListener,
     VhostUserSlaveReqHandler,
 };
+use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use vm_memory::guest_memory::FileOffset;
 use vm_memory::{GuestAddress, GuestMemoryMmap};
 use vm_virtio::Queue;
@@ -68,6 +69,9 @@ pub trait VhostUserBackend: Send + Sync + 'static {
 
     /// Virtio protocol features.
     fn protocol_features(&self) -> VhostUserProtocolFeatures;
+
+    /// Tell the backend if EVENT_IDX has been negotiated.
+    fn set_event_idx(&mut self, enabled: bool);
 
     /// Update guest memory regions.
     fn update_memory(&mut self, mem: GuestMemoryMmap) -> result::Result<(), io::Error>;
@@ -200,6 +204,8 @@ pub struct Vring {
     call: Option<EventFd>,
     err: Option<EventFd>,
     enabled: bool,
+    event_idx: bool,
+    signalled_used: Option<Wrapping<u16>>,
 }
 
 impl Vring {
@@ -210,6 +216,8 @@ impl Vring {
             call: None,
             err: None,
             enabled: false,
+            event_idx: false,
+            signalled_used: None,
         }
     }
 
@@ -217,12 +225,41 @@ impl Vring {
         &mut self.queue
     }
 
-    pub fn signal_used_queue(&self) -> result::Result<(), io::Error> {
-        if let Some(call) = self.call.as_ref() {
-            return call.write(1);
+    pub fn set_event_idx(&mut self, enabled: bool) {
+        /* Also reset the last signalled event */
+        self.signalled_used = None;
+        self.event_idx = enabled;
+    }
+
+    pub fn needs_notification(
+        &mut self,
+        used_idx: Wrapping<u16>,
+        used_event: Option<Wrapping<u16>>,
+    ) -> bool {
+        if !self.event_idx {
+            return true;
         }
 
-        Ok(())
+        let mut notify = true;
+
+        if let Some(old_idx) = self.signalled_used {
+            if let Some(used_event) = used_event {
+                if (used_idx - used_event - Wrapping(1u16)) >= (used_idx - old_idx) {
+                    notify = false;
+                }
+            }
+        }
+
+        self.signalled_used = Some(used_idx);
+        notify
+    }
+
+    pub fn signal_used_queue(&mut self) -> result::Result<(), io::Error> {
+        if let Some(call) = self.call.as_ref() {
+            call.write(1)
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -660,6 +697,13 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             .queue
             .next_avail = Wrapping(base as u16);
         self.vrings[index as usize].write().unwrap().queue.next_used = Wrapping(base as u16);
+
+        let event_idx: bool = (self.acked_features & (1 << VIRTIO_RING_F_EVENT_IDX)) != 0;
+        self.vrings[index as usize]
+            .write()
+            .unwrap()
+            .set_event_idx(event_idx);
+        self.backend.write().unwrap().set_event_idx(event_idx);
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@ use vhost_rs::vhost_user::message::{
     VhostUserVirtioFeatures, VhostUserVringAddrFlags, VhostUserVringState,
 };
 use vhost_rs::vhost_user::{
-    Error as VhostUserError, Result as VhostUserResult, SlaveListener, VhostUserSlaveReqHandler,
+    Error as VhostUserError, Result as VhostUserResult, SlaveFsCacheReq, SlaveListener,
+    VhostUserSlaveReqHandler,
 };
 use vm_memory::guest_memory::FileOffset;
 use vm_memory::{GuestAddress, GuestMemoryMmap};
@@ -103,6 +104,11 @@ pub trait VhostUserBackend: Send + Sync + 'static {
     fn exit_event(&self) -> Option<(EventFd, Option<u16>)> {
         None
     }
+
+    /// Set slave fd.
+    /// A default implementation is provided as we cannot expect all backends
+    /// to implement this function.
+    fn set_slave_req_fd(&mut self, _vu_req: SlaveFsCacheReq) {}
 }
 
 /// This structure is the public API the backend is allowed to interact with
@@ -778,6 +784,10 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             .unwrap()
             .set_config(offset, buf)
             .map_err(VhostUserError::ReqHandlerError)
+    }
+
+    fn set_slave_req_fd(&mut self, vu_req: SlaveFsCacheReq) {
+        self.backend.write().unwrap().set_slave_req_fd(vu_req);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,6 +310,12 @@ pub struct VringWorker {
     epoll_file: File,
 }
 
+impl AsRawFd for VringWorker {
+    fn as_raw_fd(&self) -> RawFd {
+        self.epoll_file.as_raw_fd()
+    }
+}
+
 impl VringWorker {
     fn run<S: VhostUserBackend>(&self, handler: VringEpollHandler<S>) -> VringWorkerResult<()> {
         const EPOLL_EVENTS_LEN: usize = 100;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,11 @@ pub trait VhostUserBackend: Send + Sync + 'static {
     /// Depth of each queue.
     fn max_queue_size(&self) -> usize;
 
-    /// Virtio features.
+    /// Available virtio features.
     fn features(&self) -> u64;
+
+    /// Acked virtio features.
+    fn acked_features(&mut self, _features: u64) {}
 
     /// Virtio protocol features.
     fn protocol_features(&self) -> VhostUserProtocolFeatures;
@@ -576,6 +579,11 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         for vring in self.vrings.iter_mut() {
             vring.write().unwrap().enabled = vring_enabled;
         }
+
+        self.backend
+            .write()
+            .unwrap()
+            .acked_features(self.acked_features);
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,10 +85,18 @@ pub trait VhostUserBackend: Send + Sync + 'static {
     ) -> result::Result<u32, io::Error>;
 
     /// Get virtio device configuration.
-    fn get_config(&self, offset: u32, size: u32) -> Vec<u8>;
+    /// A default implementation is provided as we cannot expect all backends
+    /// to implement this function.
+    fn get_config(&self, offset: u32, size: u32) -> Vec<u8> {
+        Vec::new()
+    }
 
     /// Set virtio device configuration.
-    fn set_config(&mut self, offset: u32, buf: &[u8]) -> result::Result<(), io::Error>;
+    /// A default implementation is provided as we cannot expect all backends
+    /// to implement this function.
+    fn set_config(&mut self, offset: u32, buf: &[u8]) -> result::Result<(), io::Error> {
+        Ok(())
+    }
 }
 
 /// This structure is the public API the backend is allowed to interact with

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub trait VhostUserBackend: Send + Sync + 'static {
     /// virtqueues on its own, but does not know what to do with events
     /// happening on custom listeners.
     fn handle_event(
-        &mut self,
+        &self,
         device_event: u16,
         evset: epoll::Events,
         vrings: &[Arc<RwLock<Vring>>],
@@ -310,7 +310,7 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
         }
 
         self.backend
-            .write()
+            .read()
             .unwrap()
             .handle_event(device_event, evset, &self.vrings)
             .map_err(VringEpollHandlerError::HandleEventBackendHandling)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,8 +191,8 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
     /// Retrieve the vring worker. This is necessary to perform further
     /// actions like registering and unregistering some extra event file
     /// descriptors.
-    pub fn get_vring_worker(&self) -> Arc<VringWorker> {
-        self.handler.lock().unwrap().get_vring_worker()
+    pub fn get_vring_workers(&self) -> Vec<Arc<VringWorker>> {
+        self.handler.lock().unwrap().get_vring_workers()
     }
 }
 
@@ -545,8 +545,8 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
         })
     }
 
-    fn get_vring_worker(&self) -> Arc<VringWorker> {
-        self.workers[0].clone()
+    fn get_vring_workers(&self) -> Vec<Arc<VringWorker>> {
+        self.workers.clone()
     }
 
     fn vmm_va_to_gpa(&self, vmm_va: u64) -> VhostUserHandlerResult<u64> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,11 +235,7 @@ impl Vring {
         self.event_idx = enabled;
     }
 
-    pub fn needs_notification(
-        &mut self,
-        used_idx: Wrapping<u16>,
-        used_event: Option<Wrapping<u16>>,
-    ) -> bool {
+    pub fn needs_notification(&mut self, mem: &GuestMemoryMmap, used_idx: Wrapping<u16>) -> bool {
         if !self.event_idx {
             return true;
         }
@@ -247,7 +243,7 @@ impl Vring {
         let mut notify = true;
 
         if let Some(old_idx) = self.signalled_used {
-            if let Some(used_event) = used_event {
+            if let Some(used_event) = self.mut_queue().get_used_event(&mem) {
                 if (used_idx - used_event - Wrapping(1u16)) >= (used_idx - old_idx) {
                     notify = false;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,11 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
     /// terminate.
     pub fn wait(&mut self) -> Result<()> {
         if let Some(handle) = self.main_thread.take() {
-            handle.join().map_err(Error::WaitDaemon)?
+            match handle.join().map_err(Error::WaitDaemon)? {
+                Ok(()) => Ok(()),
+                Err(Error::HandleRequest(VhostUserError::SocketBroken(_))) => Ok(()),
+                Err(e) => Err(e),
+            }
         } else {
             Ok(())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use vhost_rs::vhost_user::{
 };
 use vm_memory::guest_memory::FileOffset;
 use vm_memory::{GuestAddress, GuestMemoryMmap};
-use vm_virtio::{DescriptorChain, Queue};
+use vm_virtio::Queue;
 use vmm_sys_util::eventfd::EventFd;
 
 #[derive(Debug)]
@@ -40,8 +40,6 @@ pub enum Error {
     WaitDaemon(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
     /// Failed handling a vhost-user request.
     HandleRequest(VhostUserError),
-    /// Failed to handle the event.
-    HandleEvent(io::Error),
     /// Failed to process queue.
     ProcessQueue(VringEpollHandlerError),
     /// Failed to register listener.
@@ -65,6 +63,9 @@ pub trait VhostUserBackend: Send + Sync + 'static {
     /// Virtio features.
     fn features(&self) -> u64;
 
+    /// Update guest memory regions.
+    fn update_memory(&mut self, mem: GuestMemoryMmap) -> result::Result<(), io::Error>;
+
     /// This function gets called if the backend registered some additional
     /// listeners onto specific file descriptors. The library can handle
     /// virtqueues on its own, but does not know what to do with events
@@ -73,28 +74,20 @@ pub trait VhostUserBackend: Send + Sync + 'static {
         &mut self,
         device_event: u16,
         evset: epoll::Events,
+        vrings: &Vec<Arc<RwLock<Vring>>>,
     ) -> result::Result<bool, io::Error>;
-
-    /// This function is responsible for the actual processing that needs to
-    /// happen when one of the virtqueues is available.
-    fn process_queue(
-        &mut self,
-        q_idx: u16,
-        avail_desc: &DescriptorChain,
-        mem: &GuestMemoryMmap,
-    ) -> result::Result<u32, io::Error>;
 
     /// Get virtio device configuration.
     /// A default implementation is provided as we cannot expect all backends
     /// to implement this function.
-    fn get_config(&self, offset: u32, size: u32) -> Vec<u8> {
+    fn get_config(&self, _offset: u32, _size: u32) -> Vec<u8> {
         Vec::new()
     }
 
     /// Set virtio device configuration.
     /// A default implementation is provided as we cannot expect all backends
     /// to implement this function.
-    fn set_config(&mut self, offset: u32, buf: &[u8]) -> result::Result<(), io::Error> {
+    fn set_config(&mut self, _offset: u32, _buf: &[u8]) -> result::Result<(), io::Error> {
         Ok(())
     }
 }
@@ -134,7 +127,7 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
     /// disconnects.
     pub fn start(&mut self) -> Result<()> {
         let mut slave_listener =
-            SlaveListener::new(self.sock_path.as_str(), false, self.handler.clone())
+            SlaveListener::new(self.sock_path.as_str(), true, self.handler.clone())
                 .map_err(Error::CreateSlaveListener)?;
         let mut slave_handler = slave_listener
             .accept()
@@ -163,11 +156,11 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
         Ok(())
     }
 
-    /// Retrieve the vring handler. This is necessary to perform further
+    /// Retrieve the vring worker. This is necessary to perform further
     /// actions like registering and unregistering some extra event file
-    /// descriptors, as well as forcing some vring to be processed.
-    pub fn get_vring_handler(&self) -> Arc<RwLock<VringEpollHandler<S>>> {
-        self.handler.lock().unwrap().get_vring_handler()
+    /// descriptors.
+    pub fn get_vring_worker(&self) -> Arc<VringWorker> {
+        self.handler.lock().unwrap().get_vring_worker()
     }
 }
 
@@ -181,7 +174,7 @@ struct Memory {
     mappings: Vec<AddrMapping>,
 }
 
-struct Vring {
+pub struct Vring {
     queue: Queue,
     kick: Option<EventFd>,
     call: Option<EventFd>,
@@ -199,6 +192,18 @@ impl Vring {
             enabled: false,
         }
     }
+
+    pub fn mut_queue(&mut self) -> &mut Queue {
+        &mut self.queue
+    }
+
+    pub fn signal_used_queue(&self) -> result::Result<(), io::Error> {
+        if let Some(call) = self.call.as_ref() {
+            return call.write(1);
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -212,143 +217,105 @@ pub enum VringEpollHandlerError {
     HandleEventReadKick(io::Error),
     /// Failed to handle the event from the backend.
     HandleEventBackendHandling(io::Error),
-    /// Failed to register vring listener.
-    RegisterVringListener(io::Error),
-    /// Failed to unregister vring listener.
-    UnregisterVringListener(io::Error),
 }
-
-impl std::fmt::Display for VringEpollHandlerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            VringEpollHandlerError::ProcessQueueBackendProcessing(e) => {
-                write!(f, "failed processing queue from backend: {}", e)
-            }
-            VringEpollHandlerError::SignalUsedQueue(e) => {
-                write!(f, "failed signalling used queue: {}", e)
-            }
-            VringEpollHandlerError::HandleEventReadKick(e) => {
-                write!(f, "failed reading from kick eventfd: {}", e)
-            }
-            VringEpollHandlerError::HandleEventBackendHandling(e) => {
-                write!(f, "failed handling event from backend: {}", e)
-            }
-            VringEpollHandlerError::RegisterVringListener(e) => {
-                write!(f, "failed registering vring listener: {}", e)
-            }
-            VringEpollHandlerError::UnregisterVringListener(e) => {
-                write!(f, "failed unregistering vring listener: {}", e)
-            }
-        }
-    }
-}
-
-impl error::Error for VringEpollHandlerError {}
 
 /// Result of vring epoll handler operations.
 type VringEpollHandlerResult<T> = std::result::Result<T, VringEpollHandlerError>;
 
-pub struct VringEpollHandler<S: VhostUserBackend> {
+struct VringEpollHandler<S: VhostUserBackend> {
     backend: Arc<RwLock<S>>,
     vrings: Vec<Arc<RwLock<Vring>>>,
-    mem: Option<GuestMemoryMmap>,
-    epoll_fd: RawFd,
 }
 
 impl<S: VhostUserBackend> VringEpollHandler<S> {
-    fn update_memory(&mut self, mem: Option<GuestMemoryMmap>) {
-        self.mem = mem;
-    }
-
-    /// Trigger the processing of a virtqueue. This function is meant to be
-    /// used by the caller whenever it might need some available queues to
-    /// send data back to the guest.
-    /// A concrete example is a backend registering one extra listener for
-    /// data that needs to be sent to the guest. When the associated event
-    /// is triggered, the backend will be invoked through its `handle_event`
-    /// implementation. And in this case, the way to handle the event is to
-    /// call into `process_queue` to let it invoke the backend implementation
-    /// of `process_queue`. With this twisted trick, all common parts related
-    /// to the virtqueues can remain part of the library.
-    pub fn process_queue(&mut self, q_idx: u16) -> VringEpollHandlerResult<()> {
-        let vring = &mut self.vrings[q_idx as usize].write().unwrap();
-        let mut used_desc_heads = vec![(0, 0); vring.queue.size as usize];
-        let mut used_count = 0;
-        if let Some(mem) = &self.mem {
-            for avail_desc in vring.queue.iter(&mem) {
-                let used_len = self
-                    .backend
-                    .write()
-                    .unwrap()
-                    .process_queue(q_idx, &avail_desc, &mem)
-                    .map_err(VringEpollHandlerError::ProcessQueueBackendProcessing)?;
-
-                used_desc_heads[used_count] = (avail_desc.index, used_len);
-                used_count += 1;
-            }
-
-            for &(desc_index, len) in &used_desc_heads[..used_count] {
-                vring.queue.add_used(&mem, desc_index, len);
-            }
-        }
-
-        if used_count > 0 {
-            if let Some(call) = &vring.call {
-                call.write(1)
-                    .map_err(VringEpollHandlerError::SignalUsedQueue)?;
-            }
-        }
-
-        Ok(())
-    }
-
     fn handle_event(
-        &mut self,
+        &self,
         device_event: u16,
         evset: epoll::Events,
     ) -> VringEpollHandlerResult<bool> {
         let num_queues = self.vrings.len();
-        match device_event as usize {
-            x if x < num_queues => {
-                if let Some(kick) = &self.vrings[device_event as usize].read().unwrap().kick {
-                    kick.read()
-                        .map_err(VringEpollHandlerError::HandleEventReadKick)?;
-                }
-
-                // If the vring is not enabled, it should not be processed.
-                // The event is only read to be discarded.
-                if !self.vrings[device_event as usize].read().unwrap().enabled {
-                    return Ok(false);
-                }
-
-                self.process_queue(device_event)?;
-                Ok(false)
+        if (device_event as usize) < num_queues {
+            if let Some(kick) = &self.vrings[device_event as usize].read().unwrap().kick {
+                kick.read()
+                    .map_err(VringEpollHandlerError::HandleEventReadKick)?;
             }
-            _ => self
-                .backend
-                .write()
-                .unwrap()
-                .handle_event(device_event, evset)
-                .map_err(VringEpollHandlerError::HandleEventBackendHandling),
-        }
-    }
 
-    fn register_vring_listener(&self, q_idx: usize) -> VringEpollHandlerResult<()> {
-        if let Some(fd) = &self.vrings[q_idx].read().unwrap().kick {
-            self.register_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, q_idx as u64)
-                .map_err(VringEpollHandlerError::RegisterVringListener)
-        } else {
-            Ok(())
+            // If the vring is not enabled, it should not be processed.
+            // The event is only read to be discarded.
+            if !self.vrings[device_event as usize].read().unwrap().enabled {
+                return Ok(false);
+            }
         }
-    }
 
-    fn unregister_vring_listener(&self, q_idx: usize) -> VringEpollHandlerResult<()> {
-        if let Some(fd) = &self.vrings[q_idx].read().unwrap().kick {
-            self.unregister_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, q_idx as u64)
-                .map_err(VringEpollHandlerError::UnregisterVringListener)
-        } else {
-            Ok(())
+        self.backend
+            .write()
+            .unwrap()
+            .handle_event(device_event, evset, &self.vrings)
+            .map_err(VringEpollHandlerError::HandleEventBackendHandling)
+    }
+}
+
+#[derive(Debug)]
+/// Errors related to vring worker.
+enum VringWorkerError {
+    /// Failed while waiting for events.
+    EpollWait(io::Error),
+    /// Failed to handle the event.
+    HandleEvent(VringEpollHandlerError),
+}
+
+/// Result of vring worker operations.
+type VringWorkerResult<T> = std::result::Result<T, VringWorkerError>;
+
+pub struct VringWorker {
+    epoll_fd: RawFd,
+}
+
+impl VringWorker {
+    fn run<S: VhostUserBackend>(&self, handler: VringEpollHandler<S>) -> VringWorkerResult<()> {
+        const EPOLL_EVENTS_LEN: usize = 100;
+        let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
+
+        'epoll: loop {
+            let num_events = match epoll::wait(self.epoll_fd, -1, &mut events[..]) {
+                Ok(res) => res,
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::Interrupted {
+                        // It's well defined from the epoll_wait() syscall
+                        // documentation that the epoll loop can be interrupted
+                        // before any of the requested events occurred or the
+                        // timeout expired. In both those cases, epoll_wait()
+                        // returns an error of type EINTR, but this should not
+                        // be considered as a regular error. Instead it is more
+                        // appropriate to retry, by calling into epoll_wait().
+                        continue;
+                    }
+                    return Err(VringWorkerError::EpollWait(e));
+                }
+            };
+
+            for event in events.iter().take(num_events) {
+                let evset = match epoll::Events::from_bits(event.events) {
+                    Some(evset) => evset,
+                    None => {
+                        let evbits = event.events;
+                        println!("epoll: ignoring unknown event set: 0x{:x}", evbits);
+                        continue;
+                    }
+                };
+
+                let ev_type = event.data as u16;
+
+                if handler
+                    .handle_event(ev_type, evset)
+                    .map_err(VringWorkerError::HandleEvent)?
+                {
+                    break 'epoll;
+                }
+            }
         }
+
+        Ok(())
     }
 
     /// Register a custom event only meaningful to the caller. When this event
@@ -390,73 +357,6 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
 }
 
 #[derive(Debug)]
-/// Errors related to vring worker.
-enum VringWorkerError {
-    /// Failed while waiting for events.
-    EpollWait(io::Error),
-    /// Failed to handle event.
-    HandleEvent(VringEpollHandlerError),
-}
-
-/// Result of vring worker operations.
-type VringWorkerResult<T> = std::result::Result<T, VringWorkerError>;
-
-struct VringWorker<S: VhostUserBackend> {
-    handler: Arc<RwLock<VringEpollHandler<S>>>,
-}
-
-impl<S: VhostUserBackend> VringWorker<S> {
-    fn run(&self, epoll_fd: RawFd) -> VringWorkerResult<()> {
-        const EPOLL_EVENTS_LEN: usize = 100;
-        let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
-
-        'epoll: loop {
-            let num_events = match epoll::wait(epoll_fd, -1, &mut events[..]) {
-                Ok(res) => res,
-                Err(e) => {
-                    if e.kind() == io::ErrorKind::Interrupted {
-                        // It's well defined from the epoll_wait() syscall
-                        // documentation that the epoll loop can be interrupted
-                        // before any of the requested events occurred or the
-                        // timeout expired. In both those cases, epoll_wait()
-                        // returns an error of type EINTR, but this should not
-                        // be considered as a regular error. Instead it is more
-                        // appropriate to retry, by calling into epoll_wait().
-                        continue;
-                    }
-                    return Err(VringWorkerError::EpollWait(e));
-                }
-            };
-
-            for event in events.iter().take(num_events) {
-                let evset = match epoll::Events::from_bits(event.events) {
-                    Some(evset) => evset,
-                    None => {
-                        let evbits = event.events;
-                        println!("epoll: ignoring unknown event set: 0x{:x}", evbits);
-                        continue;
-                    }
-                };
-
-                let ev_type = event.data as u16;
-
-                if self
-                    .handler
-                    .write()
-                    .unwrap()
-                    .handle_event(ev_type, evset)
-                    .map_err(VringWorkerError::HandleEvent)?
-                {
-                    break 'epoll;
-                }
-            }
-        }
-
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
 /// Errors related to vhost-user handler.
 pub enum VhostUserHandlerError {
     /// Failed to create epoll file descriptor.
@@ -486,7 +386,7 @@ type VhostUserHandlerResult<T> = std::result::Result<T, VhostUserHandlerError>;
 
 struct VhostUserHandler<S: VhostUserBackend> {
     backend: Arc<RwLock<S>>,
-    vring_handler: Arc<RwLock<VringEpollHandler<S>>>,
+    worker: Arc<VringWorker>,
     owned: bool,
     features_acked: bool,
     acked_features: u64,
@@ -502,28 +402,30 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
         let num_queues = backend.read().unwrap().num_queues();
         let max_queue_size = backend.read().unwrap().max_queue_size();
 
-        let vrings = vec![Arc::new(RwLock::new(Vring::new(max_queue_size as u16))); num_queues];
+        let mut vrings: Vec<Arc<RwLock<Vring>>> = Vec::new();
+        for _ in 0..num_queues {
+            let vring = Arc::new(RwLock::new(Vring::new(max_queue_size as u16)));
+            vrings.push(vring);
+        }
+
         // Create the epoll file descriptor
         let epoll_fd = epoll::create(true).map_err(VhostUserHandlerError::EpollCreateFd)?;
 
-        let vring_handler = Arc::new(RwLock::new(VringEpollHandler {
+        let vring_handler = VringEpollHandler {
             backend: backend.clone(),
             vrings: vrings.clone(),
-            mem: None,
-            epoll_fd,
-        }));
-        let worker = VringWorker {
-            handler: vring_handler.clone(),
         };
+        let vring_worker = Arc::new(VringWorker { epoll_fd });
+        let worker = vring_worker.clone();
 
         thread::Builder::new()
             .name("vring_worker".to_string())
-            .spawn(move || worker.run(epoll_fd))
+            .spawn(move || vring_worker.run(vring_handler))
             .map_err(VhostUserHandlerError::SpawnVringWorker)?;
 
         Ok(VhostUserHandler {
             backend,
-            vring_handler,
+            worker,
             owned: false,
             features_acked: false,
             acked_features: 0,
@@ -535,8 +437,8 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
         })
     }
 
-    fn get_vring_handler(&self) -> Arc<RwLock<VringEpollHandler<S>>> {
-        self.vring_handler.clone()
+    fn get_vring_worker(&self) -> Arc<VringWorker> {
+        self.worker.clone()
     }
 
     fn vmm_va_to_gpa(&self, vmm_va: u64) -> VhostUserHandlerResult<u64> {
@@ -638,7 +540,13 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         let mem = GuestMemoryMmap::from_ranges_with_files(regions).map_err(|e| {
             VhostUserError::ReqHandlerError(io::Error::new(io::ErrorKind::Other, e))
         })?;
-        self.vring_handler.write().unwrap().update_memory(Some(mem));
+        self.backend
+            .write()
+            .unwrap()
+            .update_memory(mem)
+            .map_err(|e| {
+                VhostUserError::ReqHandlerError(io::Error::new(io::ErrorKind::Other, e))
+            })?;
         self.memory = Some(Memory { mappings });
 
         Ok(())
@@ -716,13 +624,11 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         // VHOST_USER_SET_VRING_KICK, and stop ring upon receiving
         // VHOST_USER_GET_VRING_BASE.
         self.vrings[index as usize].write().unwrap().queue.ready = false;
-        self.vring_handler
-            .read()
-            .unwrap()
-            .unregister_vring_listener(index as usize)
-            .map_err(|e| {
-                VhostUserError::ReqHandlerError(io::Error::new(io::ErrorKind::Other, e))
-            })?;
+        if let Some(fd) = self.vrings[index as usize].read().unwrap().kick.as_ref() {
+            self.worker
+                .unregister_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, index as u64)
+                .map_err(VhostUserError::ReqHandlerError)?;
+        }
 
         let next_avail = self.vrings[index as usize]
             .read()
@@ -752,13 +658,11 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         // VHOST_USER_SET_VRING_KICK, and stop ring upon receiving
         // VHOST_USER_GET_VRING_BASE.
         self.vrings[index as usize].write().unwrap().queue.ready = true;
-        self.vring_handler
-            .read()
-            .unwrap()
-            .register_vring_listener(index as usize)
-            .map_err(|e| {
-                VhostUserError::ReqHandlerError(io::Error::new(io::ErrorKind::Other, e))
-            })?;
+        if let Some(fd) = self.vrings[index as usize].read().unwrap().kick.as_ref() {
+            self.worker
+                .register_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, index as u64)
+                .map_err(VhostUserError::ReqHandlerError)?;
+        }
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
 struct AddrMapping {
     vmm_addr: u64,
     size: u64,
+    offset: u64,
 }
 
 struct Memory {
@@ -542,7 +543,7 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
         if let Some(memory) = &self.memory {
             for mapping in memory.mappings.iter() {
                 if vmm_va >= mapping.vmm_addr && vmm_va < mapping.vmm_addr + mapping.size {
-                    return Ok(vmm_va - mapping.vmm_addr);
+                    return Ok(vmm_va - mapping.vmm_addr + mapping.offset);
                 }
             }
         }
@@ -629,7 +630,8 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             regions.push((g_addr, len, Some(f_off)));
             mappings.push(AddrMapping {
                 vmm_addr: region.user_addr,
-                size: region.memory_size + region.mmap_offset,
+                size: region.memory_size,
+                offset: region.mmap_offset,
             });
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub trait VhostUserBackend: Send + Sync + 'static {
         &mut self,
         device_event: u16,
         evset: epoll::Events,
-        vrings: &Vec<Arc<RwLock<Vring>>>,
+        vrings: &[Arc<RwLock<Vring>>],
     ) -> result::Result<bool, io::Error>;
 
     /// Get virtio device configuration.
@@ -626,7 +626,7 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         self.vrings[index as usize].write().unwrap().queue.ready = false;
         if let Some(fd) = self.vrings[index as usize].read().unwrap().kick.as_ref() {
             self.worker
-                .unregister_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, index as u64)
+                .unregister_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, u64::from(index))
                 .map_err(VhostUserError::ReqHandlerError)?;
         }
 
@@ -660,7 +660,7 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         self.vrings[index as usize].write().unwrap().queue.ready = true;
         if let Some(fd) = self.vrings[index as usize].read().unwrap().kick.as_ref() {
             self.worker
-                .register_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, index as u64)
+                .register_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, u64::from(index))
                 .map_err(VhostUserError::ReqHandlerError)?;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,9 +478,7 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
     }
 
     fn set_features(&mut self, features: u64) -> VhostUserResult<()> {
-        if !self.owned {
-            return Err(VhostUserError::InvalidOperation);
-        } else if (features & !self.backend.read().unwrap().features()) != 0 {
+        if (features & !self.backend.read().unwrap().features()) != 0 {
             return Err(VhostUserError::InvalidParam);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@ use std::thread;
 use vhost_rs::vhost_user::message::{
     VhostUserConfigFlags, VhostUserMemoryRegion, VhostUserProtocolFeatures,
     VhostUserVirtioFeatures, VhostUserVringAddrFlags, VhostUserVringState,
-    VHOST_USER_CONFIG_OFFSET, VHOST_USER_CONFIG_SIZE,
 };
 use vhost_rs::vhost_user::{
     Error as VhostUserError, Result as VhostUserResult, SlaveListener, VhostUserSlaveReqHandler,
@@ -721,16 +720,6 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         size: u32,
         _flags: VhostUserConfigFlags,
     ) -> VhostUserResult<Vec<u8>> {
-        if self.acked_features & VhostUserProtocolFeatures::CONFIG.bits() == 0 {
-            return Err(VhostUserError::InvalidOperation);
-        } else if offset < VHOST_USER_CONFIG_OFFSET
-            || offset >= VHOST_USER_CONFIG_SIZE
-            || size > VHOST_USER_CONFIG_SIZE - VHOST_USER_CONFIG_OFFSET
-            || size + offset > VHOST_USER_CONFIG_SIZE
-        {
-            return Err(VhostUserError::InvalidParam);
-        }
-
         Ok(self.backend.read().unwrap().get_config(offset, size))
     }
 
@@ -740,17 +729,6 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         buf: &[u8],
         _flags: VhostUserConfigFlags,
     ) -> VhostUserResult<()> {
-        let size = buf.len() as u32;
-        if self.acked_features & VhostUserProtocolFeatures::CONFIG.bits() == 0 {
-            return Err(VhostUserError::InvalidOperation);
-        } else if offset < VHOST_USER_CONFIG_OFFSET
-            || offset >= VHOST_USER_CONFIG_SIZE
-            || size > VHOST_USER_CONFIG_SIZE - VHOST_USER_CONFIG_OFFSET
-            || size + offset > VHOST_USER_CONFIG_SIZE
-        {
-            return Err(VhostUserError::InvalidParam);
-        }
-
         self.backend
             .write()
             .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
 struct AddrMapping {
     vmm_addr: u64,
     size: u64,
-    offset: u64,
+    gpa_base: u64,
 }
 
 struct Memory {
@@ -447,7 +447,7 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
         if let Some(memory) = &self.memory {
             for mapping in memory.mappings.iter() {
                 if vmm_va >= mapping.vmm_addr && vmm_va < mapping.vmm_addr + mapping.size {
-                    return Ok(vmm_va - mapping.vmm_addr + mapping.offset);
+                    return Ok(vmm_va - mapping.vmm_addr + mapping.gpa_base);
                 }
             }
         }
@@ -525,15 +525,15 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
 
         for (idx, region) in ctx.iter().enumerate() {
             let g_addr = GuestAddress(region.guest_phys_addr);
-            let len = (region.memory_size + region.mmap_offset) as usize;
+            let len = region.memory_size as usize;
             let file = unsafe { File::from_raw_fd(fds[idx]) };
-            let f_off = FileOffset::new(file, 0);
+            let f_off = FileOffset::new(file, region.mmap_offset);
 
             regions.push((g_addr, len, Some(f_off)));
             mappings.push(AddrMapping {
                 vmm_addr: region.user_addr,
                 size: region.memory_size,
-                offset: region.mmap_offset,
+                gpa_base: region.guest_phys_addr,
             });
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use std::io;
 use std::num::Wrapping;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::result;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use vhost_rs::vhost_user::message::{
     VhostUserConfigFlags, VhostUserMemoryRegion, VhostUserProtocolFeatures,
@@ -90,7 +90,7 @@ pub struct VhostUserDaemon<S: VhostUserBackend> {
     name: String,
     sock_path: String,
     handler: Arc<Mutex<VhostUserHandler<S>>>,
-    vring_handler: Arc<Mutex<VringEpollHandler<S>>>,
+    vring_handler: Arc<RwLock<VringEpollHandler<S>>>,
     main_thread: Option<thread::JoinHandle<Result<()>>>,
 }
 
@@ -158,7 +158,7 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
         data: u64,
     ) -> result::Result<(), io::Error> {
         self.vring_handler
-            .lock()
+            .read()
             .unwrap()
             .register_listener(fd, ev_type, data)
     }
@@ -173,7 +173,7 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
         data: u64,
     ) -> result::Result<(), io::Error> {
         self.vring_handler
-            .lock()
+            .read()
             .unwrap()
             .unregister_listener(fd, ev_type, data)
     }
@@ -189,7 +189,7 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
     /// of `process_queue`. With this twisted trick, all common parts related
     /// to the virtqueues can remain part of the library.
     pub fn process_queue(&self, q_idx: u16) -> Result<()> {
-        self.vring_handler.lock().unwrap().process_queue(q_idx)
+        self.vring_handler.read().unwrap().process_queue(q_idx)
     }
 }
 
@@ -257,7 +257,7 @@ impl Vring {
 
 struct VringEpollHandler<S: VhostUserBackend> {
     backend: Arc<S>,
-    vrings: Arc<Mutex<Vec<Vring>>>,
+    vrings: Arc<RwLock<Vec<Vring>>>,
     mem: Option<GuestMemoryMmap>,
     epoll_fd: RawFd,
 }
@@ -268,7 +268,7 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
     }
 
     fn process_queue(&self, q_idx: u16) -> Result<()> {
-        let vring = &mut self.vrings.lock().unwrap()[q_idx as usize];
+        let vring = &mut self.vrings.write().unwrap()[q_idx as usize];
         let mut used_desc_heads = vec![(0, 0); vring.queue.size as usize];
         let mut used_count = 0;
         if let Some(mem) = &self.mem {
@@ -296,11 +296,11 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
         Ok(())
     }
 
-    fn handle_event(&mut self, device_event: u16, evset: epoll::Events) -> Result<bool> {
-        let num_queues = self.vrings.lock().unwrap().len();
+    fn handle_event(&self, device_event: u16, evset: epoll::Events) -> Result<bool> {
+        let num_queues = self.vrings.read().unwrap().len();
         match device_event as usize {
             x if x < num_queues => {
-                if let Some(kick) = &self.vrings.lock().unwrap()[device_event as usize].kick {
+                if let Some(kick) = &self.vrings.read().unwrap()[device_event as usize].kick {
                     kick.read().unwrap();
                 }
 
@@ -313,7 +313,7 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
     }
 
     fn register_vring_listener(&self, q_idx: usize) -> result::Result<(), io::Error> {
-        if let Some(fd) = &self.vrings.lock().unwrap()[q_idx].kick {
+        if let Some(fd) = &self.vrings.read().unwrap()[q_idx].kick {
             self.register_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, q_idx as u64)
         } else {
             Ok(())
@@ -321,7 +321,7 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
     }
 
     fn unregister_vring_listener(&self, q_idx: usize) -> result::Result<(), io::Error> {
-        if let Some(fd) = &self.vrings.lock().unwrap()[q_idx].kick {
+        if let Some(fd) = &self.vrings.read().unwrap()[q_idx].kick {
             self.unregister_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, q_idx as u64)
         } else {
             Ok(())
@@ -358,7 +358,7 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
 }
 
 struct VringWorker<S: VhostUserBackend> {
-    handler: Arc<Mutex<VringEpollHandler<S>>>,
+    handler: Arc<RwLock<VringEpollHandler<S>>>,
 }
 
 impl<S: VhostUserBackend> VringWorker<S> {
@@ -396,7 +396,7 @@ impl<S: VhostUserBackend> VringWorker<S> {
 
                 let ev_type = event.data as u16;
 
-                if self.handler.lock().unwrap().handle_event(ev_type, evset)? {
+                if self.handler.read().unwrap().handle_event(ev_type, evset)? {
                     break 'epoll;
                 }
             }
@@ -408,7 +408,7 @@ impl<S: VhostUserBackend> VringWorker<S> {
 
 struct VhostUserHandler<S: VhostUserBackend> {
     backend: Arc<S>,
-    vring_handler: Arc<Mutex<VringEpollHandler<S>>>,
+    vring_handler: Arc<RwLock<VringEpollHandler<S>>>,
     owned: bool,
     features_acked: bool,
     acked_features: u64,
@@ -416,7 +416,7 @@ struct VhostUserHandler<S: VhostUserBackend> {
     num_queues: usize,
     max_queue_size: usize,
     memory: Option<Memory>,
-    vrings: Arc<Mutex<Vec<Vring>>>,
+    vrings: Arc<RwLock<Vec<Vring>>>,
 }
 
 impl<S: VhostUserBackend> VhostUserHandler<S> {
@@ -425,14 +425,14 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
         let max_queue_size = backend.max_queue_size();
 
         let arc_backend = Arc::new(backend);
-        let vrings = Arc::new(Mutex::new(vec![
+        let vrings = Arc::new(RwLock::new(vec![
             Vring::new(max_queue_size as u16);
             num_queues
         ]));
         // Create the epoll file descriptor
         let epoll_fd = epoll::create(true).unwrap();
 
-        let vring_handler = Arc::new(Mutex::new(VringEpollHandler {
+        let vring_handler = Arc::new(RwLock::new(VringEpollHandler {
             backend: arc_backend.clone(),
             vrings: vrings.clone(),
             mem: None,
@@ -461,7 +461,7 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
         }
     }
 
-    fn get_vring_handler(&self) -> Arc<Mutex<VringEpollHandler<S>>> {
+    fn get_vring_handler(&self) -> Arc<RwLock<VringEpollHandler<S>>> {
         self.vring_handler.clone()
     }
 
@@ -518,7 +518,7 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         // been disabled by VHOST_USER_SET_VRING_ENABLE with parameter 0.
         let vring_enabled =
             self.acked_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits() == 0;
-        for vring in self.vrings.lock().unwrap().iter_mut() {
+        for vring in self.vrings.write().unwrap().iter_mut() {
             vring.enabled = vring_enabled;
         }
 
@@ -561,7 +561,7 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         }
 
         let mem = GuestMemoryMmap::from_ranges_with_files(regions).unwrap();
-        self.vring_handler.lock().unwrap().update_memory(Some(mem));
+        self.vring_handler.write().unwrap().update_memory(Some(mem));
         self.memory = Some(Memory { mappings });
 
         Ok(())
@@ -575,7 +575,7 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         if index as usize >= self.num_queues || num == 0 || num as usize > self.max_queue_size {
             return Err(VhostUserError::InvalidParam);
         }
-        self.vrings.lock().unwrap()[index as usize].queue.size = num as u16;
+        self.vrings.write().unwrap()[index as usize].queue.size = num as u16;
         Ok(())
     }
 
@@ -596,9 +596,13 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             let desc_table = self.vmm_va_to_gpa(descriptor).unwrap();
             let avail_ring = self.vmm_va_to_gpa(available).unwrap();
             let used_ring = self.vmm_va_to_gpa(used).unwrap();
-            self.vrings.lock().unwrap()[index as usize].queue.desc_table = GuestAddress(desc_table);
-            self.vrings.lock().unwrap()[index as usize].queue.avail_ring = GuestAddress(avail_ring);
-            self.vrings.lock().unwrap()[index as usize].queue.used_ring = GuestAddress(used_ring);
+            self.vrings.write().unwrap()[index as usize]
+                .queue
+                .desc_table = GuestAddress(desc_table);
+            self.vrings.write().unwrap()[index as usize]
+                .queue
+                .avail_ring = GuestAddress(avail_ring);
+            self.vrings.write().unwrap()[index as usize].queue.used_ring = GuestAddress(used_ring);
             Ok(())
         } else {
             Err(VhostUserError::InvalidParam)
@@ -606,8 +610,10 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
     }
 
     fn set_vring_base(&mut self, index: u32, base: u32) -> VhostUserResult<()> {
-        self.vrings.lock().unwrap()[index as usize].queue.next_avail = Wrapping(base as u16);
-        self.vrings.lock().unwrap()[index as usize].queue.next_used = Wrapping(base as u16);
+        self.vrings.write().unwrap()[index as usize]
+            .queue
+            .next_avail = Wrapping(base as u16);
+        self.vrings.write().unwrap()[index as usize].queue.next_used = Wrapping(base as u16);
         Ok(())
     }
 
@@ -620,14 +626,14 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         // that file descriptor is readable) on the descriptor specified by
         // VHOST_USER_SET_VRING_KICK, and stop ring upon receiving
         // VHOST_USER_GET_VRING_BASE.
-        self.vrings.lock().unwrap()[index as usize].started = false;
+        self.vrings.write().unwrap()[index as usize].started = false;
         self.vring_handler
-            .lock()
+            .read()
             .unwrap()
             .unregister_vring_listener(index as usize)
             .unwrap();
 
-        let next_avail = self.vrings.lock().unwrap()[index as usize]
+        let next_avail = self.vrings.read().unwrap()[index as usize]
             .queue
             .next_avail
             .0 as u16;
@@ -640,11 +646,11 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             return Err(VhostUserError::InvalidParam);
         }
 
-        if self.vrings.lock().unwrap()[index as usize].kick.is_some() {
+        if self.vrings.read().unwrap()[index as usize].kick.is_some() {
             // Close file descriptor set by previous operations.
             let _ = unsafe {
                 libc::close(
-                    self.vrings.lock().unwrap()[index as usize]
+                    self.vrings.write().unwrap()[index as usize]
                         .kick
                         .take()
                         .unwrap()
@@ -652,7 +658,7 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
                 )
             };
         }
-        self.vrings.lock().unwrap()[index as usize].kick =
+        self.vrings.write().unwrap()[index as usize].kick =
             Some(unsafe { EventFd::from_raw_fd(fd.unwrap()) });;
 
         // Quotation from vhost-user spec:
@@ -662,9 +668,9 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         // VHOST_USER_GET_VRING_BASE.
         //
         // So we should add fd to event monitor(select, poll, epoll) here.
-        self.vrings.lock().unwrap()[index as usize].started = true;
+        self.vrings.write().unwrap()[index as usize].started = true;
         self.vring_handler
-            .lock()
+            .read()
             .unwrap()
             .register_vring_listener(index as usize)
             .unwrap();
@@ -677,11 +683,11 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             return Err(VhostUserError::InvalidParam);
         }
 
-        if self.vrings.lock().unwrap()[index as usize].call.is_some() {
+        if self.vrings.write().unwrap()[index as usize].call.is_some() {
             // Close file descriptor set by previous operations.
             let _ = unsafe {
                 libc::close(
-                    self.vrings.lock().unwrap()[index as usize]
+                    self.vrings.write().unwrap()[index as usize]
                         .call
                         .take()
                         .unwrap()
@@ -689,7 +695,7 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
                 )
             };
         }
-        self.vrings.lock().unwrap()[index as usize].call =
+        self.vrings.write().unwrap()[index as usize].call =
             Some(unsafe { EventFd::from_raw_fd(fd.unwrap()) });
 
         Ok(())
@@ -700,11 +706,11 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             return Err(VhostUserError::InvalidParam);
         }
 
-        if self.vrings.lock().unwrap()[index as usize].err.is_some() {
+        if self.vrings.read().unwrap()[index as usize].err.is_some() {
             // Close file descriptor set by previous operations.
             let _ = unsafe {
                 libc::close(
-                    self.vrings.lock().unwrap()[index as usize]
+                    self.vrings.write().unwrap()[index as usize]
                         .err
                         .take()
                         .unwrap()
@@ -712,7 +718,7 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
                 )
             };
         }
-        self.vrings.lock().unwrap()[index as usize].err =
+        self.vrings.write().unwrap()[index as usize].err =
             Some(unsafe { EventFd::from_raw_fd(fd.unwrap()) });
 
         Ok(())
@@ -731,7 +737,7 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         // enabled by VHOST_USER_SET_VRING_ENABLE with parameter 1,
         // or after it has been disabled by VHOST_USER_SET_VRING_ENABLE
         // with parameter 0.
-        self.vrings.lock().unwrap()[index as usize].enabled = enable;
+        self.vrings.write().unwrap()[index as usize].enabled = enable;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,778 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright 2019 Alibaba Cloud Computing. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::File;
+use std::io;
+use std::num::Wrapping;
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::result;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use vhost_rs::vhost_user::message::{
+    VhostUserConfigFlags, VhostUserMemoryRegion, VhostUserProtocolFeatures,
+    VhostUserVirtioFeatures, VhostUserVringAddrFlags, VhostUserVringState,
+    VHOST_USER_CONFIG_OFFSET, VHOST_USER_CONFIG_SIZE,
+};
+use vhost_rs::vhost_user::{
+    Error as VhostUserError, Result as VhostUserResult, SlaveReqHandler, VhostUserSlaveReqHandler,
+};
+use vm_memory::guest_memory::FileOffset;
+use vm_memory::{GuestAddress, GuestMemoryMmap};
+use vm_virtio::{DescriptorChain, Queue};
+use vmm_sys_util::eventfd::EventFd;
+
+#[derive(Debug)]
+/// Errors related to vhost-user daemon.
+pub enum Error {
+    /// Failed creating vhost-user slave handler.
+    CreateSlaveReqHandler(VhostUserError),
+    /// Failed starting daemon thread.
+    StartDaemon(io::Error),
+    /// Failed waiting for daemon thread.
+    WaitDaemon(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
+    /// Failed handling a vhost-user request.
+    HandleRequest(VhostUserError),
+    /// Could not find the mapping from memory regions.
+    MissingMemoryMapping,
+    /// Failed to create epoll file descriptor.
+    EpollCreateFd(io::Error),
+    /// Failed to add a file descriptor to the epoll handler.
+    EpollCtl(io::Error),
+    /// Failed while waiting for events.
+    EpollWait(io::Error),
+    /// Failed to signal used queue.
+    SignalUsedQueue(io::Error),
+}
+
+/// Result of vhost-user daemon operations.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// This trait must be implemented by the caller in order to provide backend
+/// specific implementation.
+pub trait VhostUserBackend: Send + Sync + 'static {
+    /// Number of queues.
+    fn num_queues(&self) -> usize;
+
+    /// Depth of each queue.
+    fn max_queue_size(&self) -> usize;
+
+    /// Virtio features.
+    fn features(&self) -> u64;
+
+    /// This function gets called if the backend registered some additional
+    /// listeners onto specific file descriptors. The library can handle
+    /// virtqueues on its own, but does not know what to do with events
+    /// happening on custom listeners.
+    fn handle_event(&self, device_event: u16, evset: epoll::Events) -> Result<bool>;
+
+    /// This function is responsible for the actual processing that needs to
+    /// happen when one of the virtqueues is available.
+    fn process_queue(
+        &self,
+        q_idx: u16,
+        avail_desc: &DescriptorChain,
+        mem: &GuestMemoryMmap,
+    ) -> Result<u32>;
+
+    /// Get virtio device configuration.
+    fn get_config(&self, offset: u32, size: u32) -> Vec<u8>;
+
+    /// Set virtio device configuration.
+    fn set_config(&self, offset: u32, buf: &[u8]);
+}
+
+/// This structure is the public API the backend is allowed to interact with
+/// in order to run a fully functional vhost-user daemon.
+pub struct VhostUserDaemon<S: VhostUserBackend> {
+    name: String,
+    sock_path: String,
+    handler: Arc<Mutex<VhostUserHandler<S>>>,
+    vring_handler: Arc<Mutex<VringEpollHandler<S>>>,
+    main_thread: Option<thread::JoinHandle<Result<()>>>,
+}
+
+impl<S: VhostUserBackend> VhostUserDaemon<S> {
+    /// Create the daemon instance, providing the backend implementation of
+    /// VhostUserBackend.
+    /// Under the hood, this will start a dedicated thread responsible for
+    /// listening onto registered event. Those events can be vring events or
+    /// custom events from the backend, but they get to be registered later
+    /// during the sequence.
+    pub fn new(name: String, sock_path: String, backend: S) -> Result<Self> {
+        let handler = Arc::new(Mutex::new(VhostUserHandler::new(backend)));
+        let vring_handler = handler.lock().unwrap().get_vring_handler();
+
+        Ok(VhostUserDaemon {
+            name,
+            sock_path,
+            handler,
+            vring_handler,
+            main_thread: None,
+        })
+    }
+
+    /// Connect to the vhost-user socket and run a dedicated thread handling
+    /// all requests coming through this socket. This runs in an infinite loop
+    /// that should be terminating once the other end of the socket (the VMM)
+    /// disconnects.
+    pub fn start(&mut self) -> Result<()> {
+        let mut slave_handler =
+            SlaveReqHandler::connect(self.sock_path.as_str(), self.handler.clone())
+                .map_err(Error::CreateSlaveReqHandler)?;
+        let handle = thread::Builder::new()
+            .name(self.name.clone())
+            .spawn(move || loop {
+                slave_handler
+                    .handle_request()
+                    .map_err(Error::HandleRequest)?;
+            })
+            .map_err(Error::StartDaemon)?;
+
+        self.main_thread = Some(handle);
+
+        Ok(())
+    }
+
+    /// Wait for the thread handling the vhost-user socket connection to
+    /// terminate.
+    pub fn wait(&mut self) -> Result<()> {
+        if let Some(handle) = self.main_thread.take() {
+            let _ = handle.join().map_err(Error::WaitDaemon)?;
+        }
+        Ok(())
+    }
+
+    /// Register a custom event only meaningful to the caller. When this event
+    /// is later triggered, and because only the caller knows what to do about
+    /// it, the backend implementation of `handle_event` will be called.
+    /// This lets entire control to the caller about what needs to be done for
+    /// this special event, without forcing it to run its own dedicated epoll
+    /// loop for it.
+    pub fn register_listener(
+        &self,
+        fd: RawFd,
+        ev_type: epoll::Events,
+        data: u64,
+    ) -> result::Result<(), io::Error> {
+        self.vring_handler
+            .lock()
+            .unwrap()
+            .register_listener(fd, ev_type, data)
+    }
+
+    /// Unregister a custom event. If the custom event is triggered after this
+    /// function has been called, nothing will happen as it will be removed
+    /// from the list of file descriptors the epoll loop is listening to.
+    pub fn unregister_listener(
+        &self,
+        fd: RawFd,
+        ev_type: epoll::Events,
+        data: u64,
+    ) -> result::Result<(), io::Error> {
+        self.vring_handler
+            .lock()
+            .unwrap()
+            .unregister_listener(fd, ev_type, data)
+    }
+
+    /// Trigger the processing of a virtqueue. This function is meant to be
+    /// used by the caller whenever it might need some available queues to
+    /// send data back to the guest.
+    /// A concrete example is a backend registering one extra listener for
+    /// data that needs to be sent to the guest. When the associated event
+    /// is triggered, the backend will be invoked through its `handle_event`
+    /// implementation. And in this case, the way to handle the event is to
+    /// call into `process_queue` to let it invoke the backend implementation
+    /// of `process_queue`. With this twisted trick, all common parts related
+    /// to the virtqueues can remain part of the library.
+    pub fn process_queue(&self, q_idx: u16) -> Result<()> {
+        self.vring_handler.lock().unwrap().process_queue(q_idx)
+    }
+}
+
+struct AddrMapping {
+    vmm_addr: u64,
+    size: u64,
+}
+
+struct Memory {
+    mappings: Vec<AddrMapping>,
+}
+
+struct Vring {
+    queue: Queue,
+    kick: Option<EventFd>,
+    call: Option<EventFd>,
+    err: Option<EventFd>,
+    started: bool,
+    enabled: bool,
+}
+
+impl Clone for Vring {
+    fn clone(&self) -> Self {
+        let kick = if let Some(c) = &self.kick {
+            Some(c.try_clone().unwrap())
+        } else {
+            None
+        };
+
+        let call = if let Some(c) = &self.call {
+            Some(c.try_clone().unwrap())
+        } else {
+            None
+        };
+
+        let err = if let Some(e) = &self.err {
+            Some(e.try_clone().unwrap())
+        } else {
+            None
+        };
+
+        Vring {
+            queue: self.queue.clone(),
+            kick,
+            call,
+            err,
+            started: self.started,
+            enabled: self.enabled,
+        }
+    }
+}
+
+impl Vring {
+    fn new(max_queue_size: u16) -> Self {
+        Vring {
+            queue: Queue::new(max_queue_size),
+            kick: None,
+            call: None,
+            err: None,
+            started: false,
+            enabled: false,
+        }
+    }
+}
+
+struct VringEpollHandler<S: VhostUserBackend> {
+    backend: Arc<S>,
+    vrings: Arc<Mutex<Vec<Vring>>>,
+    mem: Option<GuestMemoryMmap>,
+    epoll_fd: RawFd,
+}
+
+impl<S: VhostUserBackend> VringEpollHandler<S> {
+    fn update_memory(&mut self, mem: Option<GuestMemoryMmap>) {
+        self.mem = mem;
+    }
+
+    fn process_queue(&self, q_idx: u16) -> Result<()> {
+        let vring = &mut self.vrings.lock().unwrap()[q_idx as usize];
+        let mut used_desc_heads = vec![(0, 0); vring.queue.size as usize];
+        let mut used_count = 0;
+        if let Some(mem) = &self.mem {
+            for avail_desc in vring.queue.iter(&mem) {
+                let used_len = self
+                    .backend
+                    .process_queue(q_idx, &avail_desc, &mem)
+                    .unwrap();
+
+                used_desc_heads[used_count] = (avail_desc.index, used_len);
+                used_count += 1;
+            }
+
+            for &(desc_index, len) in &used_desc_heads[..used_count] {
+                vring.queue.add_used(&mem, desc_index, len);
+            }
+        }
+
+        if used_count > 0 {
+            if let Some(call) = &vring.call {
+                return call.write(1).map_err(Error::SignalUsedQueue);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn handle_event(&mut self, device_event: u16, evset: epoll::Events) -> Result<bool> {
+        let num_queues = self.vrings.lock().unwrap().len();
+        match device_event as usize {
+            x if x < num_queues => {
+                if let Some(kick) = &self.vrings.lock().unwrap()[device_event as usize].kick {
+                    kick.read().unwrap();
+                }
+
+                self.process_queue(device_event).unwrap();
+
+                Ok(false)
+            }
+            _ => self.backend.handle_event(device_event, evset),
+        }
+    }
+
+    fn register_vring_listener(&self, q_idx: usize) -> result::Result<(), io::Error> {
+        if let Some(fd) = &self.vrings.lock().unwrap()[q_idx].kick {
+            self.register_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, q_idx as u64)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn unregister_vring_listener(&self, q_idx: usize) -> result::Result<(), io::Error> {
+        if let Some(fd) = &self.vrings.lock().unwrap()[q_idx].kick {
+            self.unregister_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, q_idx as u64)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn register_listener(
+        &self,
+        fd: RawFd,
+        ev_type: epoll::Events,
+        data: u64,
+    ) -> result::Result<(), io::Error> {
+        epoll::ctl(
+            self.epoll_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            fd,
+            epoll::Event::new(ev_type, data),
+        )
+    }
+
+    fn unregister_listener(
+        &self,
+        fd: RawFd,
+        ev_type: epoll::Events,
+        data: u64,
+    ) -> result::Result<(), io::Error> {
+        epoll::ctl(
+            self.epoll_fd,
+            epoll::ControlOptions::EPOLL_CTL_DEL,
+            fd,
+            epoll::Event::new(ev_type, data),
+        )
+    }
+}
+
+struct VringWorker<S: VhostUserBackend> {
+    handler: Arc<Mutex<VringEpollHandler<S>>>,
+}
+
+impl<S: VhostUserBackend> VringWorker<S> {
+    fn run(&self, epoll_fd: RawFd) -> Result<()> {
+        const EPOLL_EVENTS_LEN: usize = 100;
+        let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
+
+        'epoll: loop {
+            let num_events = match epoll::wait(epoll_fd, -1, &mut events[..]) {
+                Ok(res) => res,
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::Interrupted {
+                        // It's well defined from the epoll_wait() syscall
+                        // documentation that the epoll loop can be interrupted
+                        // before any of the requested events occurred or the
+                        // timeout expired. In both those cases, epoll_wait()
+                        // returns an error of type EINTR, but this should not
+                        // be considered as a regular error. Instead it is more
+                        // appropriate to retry, by calling into epoll_wait().
+                        continue;
+                    }
+                    return Err(Error::EpollWait(e));
+                }
+            };
+
+            for event in events.iter().take(num_events) {
+                let evset = match epoll::Events::from_bits(event.events) {
+                    Some(evset) => evset,
+                    None => {
+                        let evbits = event.events;
+                        println!("epoll: ignoring unknown event set: 0x{:x}", evbits);
+                        continue;
+                    }
+                };
+
+                let ev_type = event.data as u16;
+
+                if self.handler.lock().unwrap().handle_event(ev_type, evset)? {
+                    break 'epoll;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+struct VhostUserHandler<S: VhostUserBackend> {
+    backend: Arc<S>,
+    vring_handler: Arc<Mutex<VringEpollHandler<S>>>,
+    owned: bool,
+    features_acked: bool,
+    acked_features: u64,
+    acked_protocol_features: u64,
+    num_queues: usize,
+    max_queue_size: usize,
+    memory: Option<Memory>,
+    vrings: Arc<Mutex<Vec<Vring>>>,
+}
+
+impl<S: VhostUserBackend> VhostUserHandler<S> {
+    fn new(backend: S) -> Self {
+        let num_queues = backend.num_queues();
+        let max_queue_size = backend.max_queue_size();
+
+        let arc_backend = Arc::new(backend);
+        let vrings = Arc::new(Mutex::new(vec![
+            Vring::new(max_queue_size as u16);
+            num_queues
+        ]));
+        // Create the epoll file descriptor
+        let epoll_fd = epoll::create(true).unwrap();
+
+        let vring_handler = Arc::new(Mutex::new(VringEpollHandler {
+            backend: arc_backend.clone(),
+            vrings: vrings.clone(),
+            mem: None,
+            epoll_fd,
+        }));
+        let worker = VringWorker {
+            handler: vring_handler.clone(),
+        };
+
+        thread::Builder::new()
+            .name("vring_epoll_handler".to_string())
+            .spawn(move || worker.run(epoll_fd))
+            .unwrap();
+
+        VhostUserHandler {
+            backend: arc_backend,
+            vring_handler,
+            owned: false,
+            features_acked: false,
+            acked_features: 0,
+            acked_protocol_features: 0,
+            num_queues,
+            max_queue_size,
+            memory: None,
+            vrings,
+        }
+    }
+
+    fn get_vring_handler(&self) -> Arc<Mutex<VringEpollHandler<S>>> {
+        self.vring_handler.clone()
+    }
+
+    fn vmm_va_to_gpa(&self, vmm_va: u64) -> Result<u64> {
+        if let Some(memory) = &self.memory {
+            for mapping in memory.mappings.iter() {
+                if vmm_va >= mapping.vmm_addr && vmm_va < mapping.vmm_addr + mapping.size {
+                    return Ok(vmm_va - mapping.vmm_addr);
+                }
+            }
+        }
+
+        Err(Error::MissingMemoryMapping)
+    }
+}
+
+impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
+    fn set_owner(&mut self) -> VhostUserResult<()> {
+        if self.owned {
+            return Err(VhostUserError::InvalidOperation);
+        }
+        self.owned = true;
+        Ok(())
+    }
+
+    fn reset_owner(&mut self) -> VhostUserResult<()> {
+        self.owned = false;
+        self.features_acked = false;
+        self.acked_features = 0;
+        self.acked_protocol_features = 0;
+        Ok(())
+    }
+
+    fn get_features(&mut self) -> VhostUserResult<u64> {
+        Ok(self.backend.features())
+    }
+
+    fn set_features(&mut self, features: u64) -> VhostUserResult<()> {
+        if !self.owned || self.features_acked {
+            return Err(VhostUserError::InvalidOperation);
+        } else if (features & !self.backend.features()) != 0 {
+            return Err(VhostUserError::InvalidParam);
+        }
+
+        self.acked_features = features;
+        self.features_acked = true;
+
+        // If VHOST_USER_F_PROTOCOL_FEATURES has not been negotiated,
+        // the ring is initialized in an enabled state.
+        // If VHOST_USER_F_PROTOCOL_FEATURES has been negotiated,
+        // the ring is initialized in a disabled state. Client must not
+        // pass data to/from the backend until ring is enabled by
+        // VHOST_USER_SET_VRING_ENABLE with parameter 1, or after it has
+        // been disabled by VHOST_USER_SET_VRING_ENABLE with parameter 0.
+        let vring_enabled =
+            self.acked_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits() == 0;
+        for vring in self.vrings.lock().unwrap().iter_mut() {
+            vring.enabled = vring_enabled;
+        }
+
+        Ok(())
+    }
+
+    fn get_protocol_features(&mut self) -> VhostUserResult<VhostUserProtocolFeatures> {
+        Ok(VhostUserProtocolFeatures::all())
+    }
+
+    fn set_protocol_features(&mut self, features: u64) -> VhostUserResult<()> {
+        // Note: slave that reported VHOST_USER_F_PROTOCOL_FEATURES must
+        // support this message even before VHOST_USER_SET_FEATURES was
+        // called.
+        self.acked_protocol_features = features;
+        Ok(())
+    }
+
+    fn set_mem_table(
+        &mut self,
+        ctx: &[VhostUserMemoryRegion],
+        fds: &[RawFd],
+    ) -> VhostUserResult<()> {
+        // We need to create tuple of ranges from the list of VhostUserMemoryRegion
+        // that we get from the caller.
+        let mut regions: Vec<(GuestAddress, usize, Option<FileOffset>)> = Vec::new();
+        let mut mappings: Vec<AddrMapping> = Vec::new();
+
+        for (idx, region) in ctx.iter().enumerate() {
+            let g_addr = GuestAddress(region.guest_phys_addr);
+            let len = (region.memory_size + region.mmap_offset) as usize;
+            let file = unsafe { File::from_raw_fd(fds[idx]) };
+            let f_off = FileOffset::new(file, 0);
+
+            regions.push((g_addr, len, Some(f_off)));
+            mappings.push(AddrMapping {
+                vmm_addr: region.user_addr,
+                size: region.memory_size + region.mmap_offset,
+            });
+        }
+
+        let mem = GuestMemoryMmap::from_ranges_with_files(regions).unwrap();
+        self.vring_handler.lock().unwrap().update_memory(Some(mem));
+        self.memory = Some(Memory { mappings });
+
+        Ok(())
+    }
+
+    fn get_queue_num(&mut self) -> VhostUserResult<u64> {
+        Ok(self.num_queues as u64)
+    }
+
+    fn set_vring_num(&mut self, index: u32, num: u32) -> VhostUserResult<()> {
+        if index as usize >= self.num_queues || num == 0 || num as usize > self.max_queue_size {
+            return Err(VhostUserError::InvalidParam);
+        }
+        self.vrings.lock().unwrap()[index as usize].queue.size = num as u16;
+        Ok(())
+    }
+
+    fn set_vring_addr(
+        &mut self,
+        index: u32,
+        _flags: VhostUserVringAddrFlags,
+        descriptor: u64,
+        used: u64,
+        available: u64,
+        _log: u64,
+    ) -> VhostUserResult<()> {
+        if index as usize >= self.num_queues {
+            return Err(VhostUserError::InvalidParam);
+        }
+
+        if self.memory.is_some() {
+            let desc_table = self.vmm_va_to_gpa(descriptor).unwrap();
+            let avail_ring = self.vmm_va_to_gpa(available).unwrap();
+            let used_ring = self.vmm_va_to_gpa(used).unwrap();
+            self.vrings.lock().unwrap()[index as usize].queue.desc_table = GuestAddress(desc_table);
+            self.vrings.lock().unwrap()[index as usize].queue.avail_ring = GuestAddress(avail_ring);
+            self.vrings.lock().unwrap()[index as usize].queue.used_ring = GuestAddress(used_ring);
+            Ok(())
+        } else {
+            Err(VhostUserError::InvalidParam)
+        }
+    }
+
+    fn set_vring_base(&mut self, index: u32, base: u32) -> VhostUserResult<()> {
+        self.vrings.lock().unwrap()[index as usize].queue.next_avail = Wrapping(base as u16);
+        self.vrings.lock().unwrap()[index as usize].queue.next_used = Wrapping(base as u16);
+        Ok(())
+    }
+
+    fn get_vring_base(&mut self, index: u32) -> VhostUserResult<VhostUserVringState> {
+        if index as usize >= self.num_queues {
+            return Err(VhostUserError::InvalidParam);
+        }
+        // Quotation from vhost-user spec:
+        // Client must start ring upon receiving a kick (that is, detecting
+        // that file descriptor is readable) on the descriptor specified by
+        // VHOST_USER_SET_VRING_KICK, and stop ring upon receiving
+        // VHOST_USER_GET_VRING_BASE.
+        self.vrings.lock().unwrap()[index as usize].started = false;
+        self.vring_handler
+            .lock()
+            .unwrap()
+            .unregister_vring_listener(index as usize)
+            .unwrap();
+
+        let next_avail = self.vrings.lock().unwrap()[index as usize]
+            .queue
+            .next_avail
+            .0 as u16;
+
+        Ok(VhostUserVringState::new(index, u32::from(next_avail)))
+    }
+
+    fn set_vring_kick(&mut self, index: u8, fd: Option<RawFd>) -> VhostUserResult<()> {
+        if index as usize >= self.num_queues {
+            return Err(VhostUserError::InvalidParam);
+        }
+
+        if self.vrings.lock().unwrap()[index as usize].kick.is_some() {
+            // Close file descriptor set by previous operations.
+            let _ = unsafe {
+                libc::close(
+                    self.vrings.lock().unwrap()[index as usize]
+                        .kick
+                        .take()
+                        .unwrap()
+                        .as_raw_fd(),
+                )
+            };
+        }
+        self.vrings.lock().unwrap()[index as usize].kick =
+            Some(unsafe { EventFd::from_raw_fd(fd.unwrap()) });;
+
+        // Quotation from vhost-user spec:
+        // Client must start ring upon receiving a kick (that is, detecting
+        // that file descriptor is readable) on the descriptor specified by
+        // VHOST_USER_SET_VRING_KICK, and stop ring upon receiving
+        // VHOST_USER_GET_VRING_BASE.
+        //
+        // So we should add fd to event monitor(select, poll, epoll) here.
+        self.vrings.lock().unwrap()[index as usize].started = true;
+        self.vring_handler
+            .lock()
+            .unwrap()
+            .register_vring_listener(index as usize)
+            .unwrap();
+
+        Ok(())
+    }
+
+    fn set_vring_call(&mut self, index: u8, fd: Option<RawFd>) -> VhostUserResult<()> {
+        if index as usize >= self.num_queues {
+            return Err(VhostUserError::InvalidParam);
+        }
+
+        if self.vrings.lock().unwrap()[index as usize].call.is_some() {
+            // Close file descriptor set by previous operations.
+            let _ = unsafe {
+                libc::close(
+                    self.vrings.lock().unwrap()[index as usize]
+                        .call
+                        .take()
+                        .unwrap()
+                        .as_raw_fd(),
+                )
+            };
+        }
+        self.vrings.lock().unwrap()[index as usize].call =
+            Some(unsafe { EventFd::from_raw_fd(fd.unwrap()) });
+
+        Ok(())
+    }
+
+    fn set_vring_err(&mut self, index: u8, fd: Option<RawFd>) -> VhostUserResult<()> {
+        if index as usize >= self.num_queues {
+            return Err(VhostUserError::InvalidParam);
+        }
+
+        if self.vrings.lock().unwrap()[index as usize].err.is_some() {
+            // Close file descriptor set by previous operations.
+            let _ = unsafe {
+                libc::close(
+                    self.vrings.lock().unwrap()[index as usize]
+                        .err
+                        .take()
+                        .unwrap()
+                        .as_raw_fd(),
+                )
+            };
+        }
+        self.vrings.lock().unwrap()[index as usize].err =
+            Some(unsafe { EventFd::from_raw_fd(fd.unwrap()) });
+
+        Ok(())
+    }
+
+    fn set_vring_enable(&mut self, index: u32, enable: bool) -> VhostUserResult<()> {
+        // This request should be handled only when VHOST_USER_F_PROTOCOL_FEATURES
+        // has been negotiated.
+        if self.acked_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits() == 0 {
+            return Err(VhostUserError::InvalidOperation);
+        } else if index as usize >= self.num_queues {
+            return Err(VhostUserError::InvalidParam);
+        }
+
+        // Slave must not pass data to/from the backend until ring is
+        // enabled by VHOST_USER_SET_VRING_ENABLE with parameter 1,
+        // or after it has been disabled by VHOST_USER_SET_VRING_ENABLE
+        // with parameter 0.
+        self.vrings.lock().unwrap()[index as usize].enabled = enable;
+
+        Ok(())
+    }
+
+    fn get_config(
+        &mut self,
+        offset: u32,
+        size: u32,
+        _flags: VhostUserConfigFlags,
+    ) -> VhostUserResult<Vec<u8>> {
+        if self.acked_features & VhostUserProtocolFeatures::CONFIG.bits() == 0 {
+            return Err(VhostUserError::InvalidOperation);
+        } else if offset < VHOST_USER_CONFIG_OFFSET
+            || offset >= VHOST_USER_CONFIG_SIZE
+            || size > VHOST_USER_CONFIG_SIZE - VHOST_USER_CONFIG_OFFSET
+            || size + offset > VHOST_USER_CONFIG_SIZE
+        {
+            return Err(VhostUserError::InvalidParam);
+        }
+
+        Ok(self.backend.get_config(offset, size))
+    }
+
+    fn set_config(
+        &mut self,
+        offset: u32,
+        buf: &[u8],
+        _flags: VhostUserConfigFlags,
+    ) -> VhostUserResult<()> {
+        let size = buf.len() as u32;
+        if self.acked_features & VhostUserProtocolFeatures::CONFIG.bits() == 0 {
+            return Err(VhostUserError::InvalidOperation);
+        } else if offset < VHOST_USER_CONFIG_OFFSET
+            || offset >= VHOST_USER_CONFIG_SIZE
+            || size > VHOST_USER_CONFIG_SIZE - VHOST_USER_CONFIG_OFFSET
+            || size + offset > VHOST_USER_CONFIG_SIZE
+        {
+            return Err(VhostUserError::InvalidParam);
+        }
+
+        self.backend.set_config(offset, buf);
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 // Copyright 2019 Alibaba Cloud Computing. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::error;
 use std::fs::File;
 use std::io;
 use std::num::Wrapping;
@@ -27,6 +28,8 @@ use vmm_sys_util::eventfd::EventFd;
 #[derive(Debug)]
 /// Errors related to vhost-user daemon.
 pub enum Error {
+    /// Failed to create a new vhost-user handler.
+    NewVhostUserHandler(VhostUserHandlerError),
     /// Failed creating vhost-user slave handler.
     CreateSlaveReqHandler(VhostUserError),
     /// Failed starting daemon thread.
@@ -35,20 +38,18 @@ pub enum Error {
     WaitDaemon(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
     /// Failed handling a vhost-user request.
     HandleRequest(VhostUserError),
-    /// Could not find the mapping from memory regions.
-    MissingMemoryMapping,
-    /// Failed to create epoll file descriptor.
-    EpollCreateFd(io::Error),
-    /// Failed to add a file descriptor to the epoll handler.
-    EpollCtl(io::Error),
-    /// Failed while waiting for events.
-    EpollWait(io::Error),
-    /// Failed to signal used queue.
-    SignalUsedQueue(io::Error),
+    /// Failed to handle the event.
+    HandleEvent(io::Error),
+    /// Failed to process queue.
+    ProcessQueue(VringEpollHandlerError),
+    /// Failed to register listener.
+    RegisterListener(io::Error),
+    /// Failed to unregister listener.
+    UnregisterListener(io::Error),
 }
 
 /// Result of vhost-user daemon operations.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = result::Result<T, Error>;
 
 /// This trait must be implemented by the caller in order to provide backend
 /// specific implementation.
@@ -66,7 +67,11 @@ pub trait VhostUserBackend: Send + Sync + 'static {
     /// listeners onto specific file descriptors. The library can handle
     /// virtqueues on its own, but does not know what to do with events
     /// happening on custom listeners.
-    fn handle_event(&mut self, device_event: u16, evset: epoll::Events) -> Result<bool>;
+    fn handle_event(
+        &mut self,
+        device_event: u16,
+        evset: epoll::Events,
+    ) -> result::Result<bool, io::Error>;
 
     /// This function is responsible for the actual processing that needs to
     /// happen when one of the virtqueues is available.
@@ -75,13 +80,13 @@ pub trait VhostUserBackend: Send + Sync + 'static {
         q_idx: u16,
         avail_desc: &DescriptorChain,
         mem: &GuestMemoryMmap,
-    ) -> Result<u32>;
+    ) -> result::Result<u32, io::Error>;
 
     /// Get virtio device configuration.
     fn get_config(&self, offset: u32, size: u32) -> Vec<u8>;
 
     /// Set virtio device configuration.
-    fn set_config(&mut self, offset: u32, buf: &[u8]);
+    fn set_config(&mut self, offset: u32, buf: &[u8]) -> result::Result<(), io::Error>;
 }
 
 /// This structure is the public API the backend is allowed to interact with
@@ -102,7 +107,9 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
     /// custom events from the backend, but they get to be registered later
     /// during the sequence.
     pub fn new(name: String, sock_path: String, backend: S) -> Result<Self> {
-        let handler = Arc::new(Mutex::new(VhostUserHandler::new(backend)));
+        let handler = Arc::new(Mutex::new(
+            VhostUserHandler::new(backend).map_err(Error::NewVhostUserHandler)?,
+        ));
         let vring_handler = handler.lock().unwrap().get_vring_handler();
 
         Ok(VhostUserDaemon {
@@ -151,31 +158,23 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
     /// This lets entire control to the caller about what needs to be done for
     /// this special event, without forcing it to run its own dedicated epoll
     /// loop for it.
-    pub fn register_listener(
-        &self,
-        fd: RawFd,
-        ev_type: epoll::Events,
-        data: u64,
-    ) -> result::Result<(), io::Error> {
+    pub fn register_listener(&self, fd: RawFd, ev_type: epoll::Events, data: u64) -> Result<()> {
         self.vring_handler
             .read()
             .unwrap()
             .register_listener(fd, ev_type, data)
+            .map_err(Error::RegisterListener)
     }
 
     /// Unregister a custom event. If the custom event is triggered after this
     /// function has been called, nothing will happen as it will be removed
     /// from the list of file descriptors the epoll loop is listening to.
-    pub fn unregister_listener(
-        &self,
-        fd: RawFd,
-        ev_type: epoll::Events,
-        data: u64,
-    ) -> result::Result<(), io::Error> {
+    pub fn unregister_listener(&self, fd: RawFd, ev_type: epoll::Events, data: u64) -> Result<()> {
         self.vring_handler
             .read()
             .unwrap()
             .unregister_listener(fd, ev_type, data)
+            .map_err(Error::RegisterListener)
     }
 
     /// Trigger the processing of a virtqueue. This function is meant to be
@@ -189,7 +188,11 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
     /// of `process_queue`. With this twisted trick, all common parts related
     /// to the virtqueues can remain part of the library.
     pub fn process_queue(&self, q_idx: u16) -> Result<()> {
-        self.vring_handler.write().unwrap().process_queue(q_idx)
+        self.vring_handler
+            .write()
+            .unwrap()
+            .process_queue(q_idx)
+            .map_err(Error::ProcessQueue)
     }
 }
 
@@ -224,6 +227,53 @@ impl Vring {
     }
 }
 
+#[derive(Debug)]
+/// Errors related to vring epoll handler.
+pub enum VringEpollHandlerError {
+    /// Failed to process the queue from the backend.
+    ProcessQueueBackendProcessing(io::Error),
+    /// Failed to signal used queue.
+    SignalUsedQueue(io::Error),
+    /// Failed to read the event from kick EventFd.
+    HandleEventReadKick(io::Error),
+    /// Failed to handle the event from the backend.
+    HandleEventBackendHandling(io::Error),
+    /// Failed to register vring listener.
+    RegisterVringListener(io::Error),
+    /// Failed to unregister vring listener.
+    UnregisterVringListener(io::Error),
+}
+
+impl std::fmt::Display for VringEpollHandlerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            VringEpollHandlerError::ProcessQueueBackendProcessing(e) => {
+                write!(f, "failed processing queue from backend: {}", e)
+            }
+            VringEpollHandlerError::SignalUsedQueue(e) => {
+                write!(f, "failed signalling used queue: {}", e)
+            }
+            VringEpollHandlerError::HandleEventReadKick(e) => {
+                write!(f, "failed reading from kick eventfd: {}", e)
+            }
+            VringEpollHandlerError::HandleEventBackendHandling(e) => {
+                write!(f, "failed handling event from backend: {}", e)
+            }
+            VringEpollHandlerError::RegisterVringListener(e) => {
+                write!(f, "failed registering vring listener: {}", e)
+            }
+            VringEpollHandlerError::UnregisterVringListener(e) => {
+                write!(f, "failed unregistering vring listener: {}", e)
+            }
+        }
+    }
+}
+
+impl error::Error for VringEpollHandlerError {}
+
+/// Result of vring epoll handler operations.
+type VringEpollHandlerResult<T> = std::result::Result<T, VringEpollHandlerError>;
+
 struct VringEpollHandler<S: VhostUserBackend> {
     backend: Arc<RwLock<S>>,
     vrings: Vec<Arc<RwLock<Vring>>>,
@@ -236,7 +286,7 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
         self.mem = mem;
     }
 
-    fn process_queue(&mut self, q_idx: u16) -> Result<()> {
+    fn process_queue(&mut self, q_idx: u16) -> VringEpollHandlerResult<()> {
         let vring = &mut self.vrings[q_idx as usize].write().unwrap();
         let mut used_desc_heads = vec![(0, 0); vring.queue.size as usize];
         let mut used_count = 0;
@@ -247,7 +297,7 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
                     .write()
                     .unwrap()
                     .process_queue(q_idx, &avail_desc, &mem)
-                    .unwrap();
+                    .map_err(VringEpollHandlerError::ProcessQueueBackendProcessing)?;
 
                 used_desc_heads[used_count] = (avail_desc.index, used_len);
                 used_count += 1;
@@ -260,44 +310,52 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
 
         if used_count > 0 {
             if let Some(call) = &vring.call {
-                return call.write(1).map_err(Error::SignalUsedQueue);
+                call.write(1)
+                    .map_err(VringEpollHandlerError::SignalUsedQueue)?;
             }
         }
 
         Ok(())
     }
 
-    fn handle_event(&mut self, device_event: u16, evset: epoll::Events) -> Result<bool> {
+    fn handle_event(
+        &mut self,
+        device_event: u16,
+        evset: epoll::Events,
+    ) -> VringEpollHandlerResult<bool> {
         let num_queues = self.vrings.len();
         match device_event as usize {
             x if x < num_queues => {
                 if let Some(kick) = &self.vrings[device_event as usize].read().unwrap().kick {
-                    kick.read().unwrap();
+                    kick.read()
+                        .map_err(VringEpollHandlerError::HandleEventReadKick)?;
                 }
 
-                self.process_queue(device_event).unwrap();
-
+                self.process_queue(device_event)?;
                 Ok(false)
             }
             _ => self
                 .backend
                 .write()
                 .unwrap()
-                .handle_event(device_event, evset),
+                .handle_event(device_event, evset)
+                .map_err(VringEpollHandlerError::HandleEventBackendHandling),
         }
     }
 
-    fn register_vring_listener(&self, q_idx: usize) -> result::Result<(), io::Error> {
+    fn register_vring_listener(&self, q_idx: usize) -> VringEpollHandlerResult<()> {
         if let Some(fd) = &self.vrings[q_idx].read().unwrap().kick {
             self.register_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, q_idx as u64)
+                .map_err(VringEpollHandlerError::RegisterVringListener)
         } else {
             Ok(())
         }
     }
 
-    fn unregister_vring_listener(&self, q_idx: usize) -> result::Result<(), io::Error> {
+    fn unregister_vring_listener(&self, q_idx: usize) -> VringEpollHandlerResult<()> {
         if let Some(fd) = &self.vrings[q_idx].read().unwrap().kick {
             self.unregister_listener(fd.as_raw_fd(), epoll::Events::EPOLLIN, q_idx as u64)
+                .map_err(VringEpollHandlerError::UnregisterVringListener)
         } else {
             Ok(())
         }
@@ -332,12 +390,24 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
     }
 }
 
+#[derive(Debug)]
+/// Errors related to vring worker.
+enum VringWorkerError {
+    /// Failed while waiting for events.
+    EpollWait(io::Error),
+    /// Failed to handle event.
+    HandleEvent(VringEpollHandlerError),
+}
+
+/// Result of vring worker operations.
+type VringWorkerResult<T> = std::result::Result<T, VringWorkerError>;
+
 struct VringWorker<S: VhostUserBackend> {
     handler: Arc<RwLock<VringEpollHandler<S>>>,
 }
 
 impl<S: VhostUserBackend> VringWorker<S> {
-    fn run(&self, epoll_fd: RawFd) -> Result<()> {
+    fn run(&self, epoll_fd: RawFd) -> VringWorkerResult<()> {
         const EPOLL_EVENTS_LEN: usize = 100;
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
@@ -355,7 +425,7 @@ impl<S: VhostUserBackend> VringWorker<S> {
                         // appropriate to retry, by calling into epoll_wait().
                         continue;
                     }
-                    return Err(Error::EpollWait(e));
+                    return Err(VringWorkerError::EpollWait(e));
                 }
             };
 
@@ -371,7 +441,13 @@ impl<S: VhostUserBackend> VringWorker<S> {
 
                 let ev_type = event.data as u16;
 
-                if self.handler.write().unwrap().handle_event(ev_type, evset)? {
+                if self
+                    .handler
+                    .write()
+                    .unwrap()
+                    .handle_event(ev_type, evset)
+                    .map_err(VringWorkerError::HandleEvent)?
+                {
                     break 'epoll;
                 }
             }
@@ -380,6 +456,34 @@ impl<S: VhostUserBackend> VringWorker<S> {
         Ok(())
     }
 }
+
+#[derive(Debug)]
+/// Errors related to vhost-user handler.
+pub enum VhostUserHandlerError {
+    /// Failed to create epoll file descriptor.
+    EpollCreateFd(io::Error),
+    /// Failed to spawn vring worker.
+    SpawnVringWorker(io::Error),
+    /// Could not find the mapping from memory regions.
+    MissingMemoryMapping,
+}
+
+impl std::fmt::Display for VhostUserHandlerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            VhostUserHandlerError::EpollCreateFd(e) => write!(f, "failed creating epoll fd: {}", e),
+            VhostUserHandlerError::SpawnVringWorker(e) => {
+                write!(f, "failed spawning the vring worker: {}", e)
+            }
+            VhostUserHandlerError::MissingMemoryMapping => write!(f, "Missing memory mapping"),
+        }
+    }
+}
+
+impl error::Error for VhostUserHandlerError {}
+
+/// Result of vhost-user handler operations.
+type VhostUserHandlerResult<T> = std::result::Result<T, VhostUserHandlerError>;
 
 struct VhostUserHandler<S: VhostUserBackend> {
     backend: Arc<RwLock<S>>,
@@ -395,14 +499,14 @@ struct VhostUserHandler<S: VhostUserBackend> {
 }
 
 impl<S: VhostUserBackend> VhostUserHandler<S> {
-    fn new(backend: S) -> Self {
+    fn new(backend: S) -> VhostUserHandlerResult<Self> {
         let num_queues = backend.num_queues();
         let max_queue_size = backend.max_queue_size();
 
         let arc_backend = Arc::new(RwLock::new(backend));
         let vrings = vec![Arc::new(RwLock::new(Vring::new(max_queue_size as u16))); num_queues];
         // Create the epoll file descriptor
-        let epoll_fd = epoll::create(true).unwrap();
+        let epoll_fd = epoll::create(true).map_err(VhostUserHandlerError::EpollCreateFd)?;
 
         let vring_handler = Arc::new(RwLock::new(VringEpollHandler {
             backend: arc_backend.clone(),
@@ -415,11 +519,11 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
         };
 
         thread::Builder::new()
-            .name("vring_epoll_handler".to_string())
+            .name("vring_worker".to_string())
             .spawn(move || worker.run(epoll_fd))
-            .unwrap();
+            .map_err(VhostUserHandlerError::SpawnVringWorker)?;
 
-        VhostUserHandler {
+        Ok(VhostUserHandler {
             backend: arc_backend,
             vring_handler,
             owned: false,
@@ -430,14 +534,14 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
             max_queue_size,
             memory: None,
             vrings,
-        }
+        })
     }
 
     fn get_vring_handler(&self) -> Arc<RwLock<VringEpollHandler<S>>> {
         self.vring_handler.clone()
     }
 
-    fn vmm_va_to_gpa(&self, vmm_va: u64) -> Result<u64> {
+    fn vmm_va_to_gpa(&self, vmm_va: u64) -> VhostUserHandlerResult<u64> {
         if let Some(memory) = &self.memory {
             for mapping in memory.mappings.iter() {
                 if vmm_va >= mapping.vmm_addr && vmm_va < mapping.vmm_addr + mapping.size {
@@ -446,7 +550,7 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
             }
         }
 
-        Err(Error::MissingMemoryMapping)
+        Err(VhostUserHandlerError::MissingMemoryMapping)
     }
 }
 
@@ -532,7 +636,9 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             });
         }
 
-        let mem = GuestMemoryMmap::from_ranges_with_files(regions).unwrap();
+        let mem = GuestMemoryMmap::from_ranges_with_files(regions).map_err(|e| {
+            VhostUserError::ReqHandlerError(io::Error::new(io::ErrorKind::Other, e))
+        })?;
         self.vring_handler.write().unwrap().update_memory(Some(mem));
         self.memory = Some(Memory { mappings });
 
@@ -565,9 +671,15 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
         }
 
         if self.memory.is_some() {
-            let desc_table = self.vmm_va_to_gpa(descriptor).unwrap();
-            let avail_ring = self.vmm_va_to_gpa(available).unwrap();
-            let used_ring = self.vmm_va_to_gpa(used).unwrap();
+            let desc_table = self.vmm_va_to_gpa(descriptor).map_err(|e| {
+                VhostUserError::ReqHandlerError(io::Error::new(io::ErrorKind::Other, e))
+            })?;
+            let avail_ring = self.vmm_va_to_gpa(available).map_err(|e| {
+                VhostUserError::ReqHandlerError(io::Error::new(io::ErrorKind::Other, e))
+            })?;
+            let used_ring = self.vmm_va_to_gpa(used).map_err(|e| {
+                VhostUserError::ReqHandlerError(io::Error::new(io::ErrorKind::Other, e))
+            })?;
             self.vrings[index as usize]
                 .write()
                 .unwrap()
@@ -609,7 +721,9 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             .read()
             .unwrap()
             .unregister_vring_listener(index as usize)
-            .unwrap();
+            .map_err(|e| {
+                VhostUserError::ReqHandlerError(io::Error::new(io::ErrorKind::Other, e))
+            })?;
 
         let next_avail = self.vrings[index as usize]
             .read()
@@ -626,22 +740,12 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             return Err(VhostUserError::InvalidParam);
         }
 
-        if self.vrings[index as usize].read().unwrap().kick.is_some() {
+        if let Some(kick) = self.vrings[index as usize].write().unwrap().kick.take() {
             // Close file descriptor set by previous operations.
-            let _ = unsafe {
-                libc::close(
-                    self.vrings[index as usize]
-                        .write()
-                        .unwrap()
-                        .kick
-                        .take()
-                        .unwrap()
-                        .as_raw_fd(),
-                )
-            };
+            let _ = unsafe { libc::close(kick.as_raw_fd()) };
         }
         self.vrings[index as usize].write().unwrap().kick =
-            Some(unsafe { EventFd::from_raw_fd(fd.unwrap()) });
+            fd.map(|x| unsafe { EventFd::from_raw_fd(x) });
 
         // Quotation from vhost-user spec:
         // Client must start ring upon receiving a kick (that is, detecting
@@ -655,7 +759,9 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             .read()
             .unwrap()
             .register_vring_listener(index as usize)
-            .unwrap();
+            .map_err(|e| {
+                VhostUserError::ReqHandlerError(io::Error::new(io::ErrorKind::Other, e))
+            })?;
 
         Ok(())
     }
@@ -665,22 +771,12 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             return Err(VhostUserError::InvalidParam);
         }
 
-        if self.vrings[index as usize].write().unwrap().call.is_some() {
+        if let Some(call) = self.vrings[index as usize].write().unwrap().call.take() {
             // Close file descriptor set by previous operations.
-            let _ = unsafe {
-                libc::close(
-                    self.vrings[index as usize]
-                        .write()
-                        .unwrap()
-                        .call
-                        .take()
-                        .unwrap()
-                        .as_raw_fd(),
-                )
-            };
+            let _ = unsafe { libc::close(call.as_raw_fd()) };
         }
         self.vrings[index as usize].write().unwrap().call =
-            Some(unsafe { EventFd::from_raw_fd(fd.unwrap()) });
+            fd.map(|x| unsafe { EventFd::from_raw_fd(x) });
 
         Ok(())
     }
@@ -690,22 +786,12 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             return Err(VhostUserError::InvalidParam);
         }
 
-        if self.vrings[index as usize].read().unwrap().err.is_some() {
+        if let Some(err) = self.vrings[index as usize].write().unwrap().err.take() {
             // Close file descriptor set by previous operations.
-            let _ = unsafe {
-                libc::close(
-                    self.vrings[index as usize]
-                        .write()
-                        .unwrap()
-                        .err
-                        .take()
-                        .unwrap()
-                        .as_raw_fd(),
-                )
-            };
+            let _ = unsafe { libc::close(err.as_raw_fd()) };
         }
         self.vrings[index as usize].write().unwrap().err =
-            Some(unsafe { EventFd::from_raw_fd(fd.unwrap()) });
+            fd.map(|x| unsafe { EventFd::from_raw_fd(x) });
 
         Ok(())
     }
@@ -764,7 +850,10 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             return Err(VhostUserError::InvalidParam);
         }
 
-        self.backend.write().unwrap().set_config(offset, buf);
-        Ok(())
+        self.backend
+            .write()
+            .unwrap()
+            .set_config(offset, buf)
+            .map_err(VhostUserError::ReqHandlerError)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,9 @@ pub trait VhostUserBackend: Send + Sync + 'static {
     /// Virtio features.
     fn features(&self) -> u64;
 
+    /// Virtio protocol features.
+    fn protocol_features(&self) -> VhostUserProtocolFeatures;
+
     /// Update guest memory regions.
     fn update_memory(&mut self, mem: GuestMemoryMmap) -> result::Result<(), io::Error>;
 
@@ -501,7 +504,7 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
     }
 
     fn get_protocol_features(&mut self) -> VhostUserResult<VhostUserProtocolFeatures> {
-        Ok(VhostUserProtocolFeatures::all())
+        Ok(self.backend.read().unwrap().protocol_features())
     }
 
     fn set_protocol_features(&mut self, features: u64) -> VhostUserResult<()> {


### PR DESCRIPTION
This PR extract vhost-user-backend patches from cloud hypervisor:
In cloud hypervisor project:
```
git log --pretty=one vhost_user_backend/ | wc -l
58
```
Remove dependency crates version upgrade patches:
```
git log --pretty=one vhost_user_backend/ |grep -i "bump\|cargo\|vmm-sys-util"  | wc -l                                               
20
git log --pretty=one vhost_user_backend/ |grep -i "bump\|cargo\|vmm-sys-util"                                                           
aac87196d6233c17165fff9efc962114b70347e6 build(deps): bump vm-memory from 0.2.0 to 0.2.1
a4bb96d45ce1020f62145bf5f7c056d2117e7a0d build(deps): bump libc from 0.2.70 to 0.2.71
2991fd2a48e449d23e03ba759b12ceffa7beb884 build(deps): bump libc from 0.2.69 to 0.2.70
886c0f9093936d9a37b96f466e1b630e64a208f8 build(deps): bump libc from 0.2.68 to 0.2.69
8acc15a63c1ea094328974f6f2de7cbad4ede1ae build: Bump vm-memory and linux-loader dependencies
51f51ea17dced01a0aad9ba718dcbe68ee0b94ad build(deps): bump libc from 0.2.67 to 0.2.68
f0a3e7c4a1d4641f92737eda8a3b813b24c8c588 build: Bump linux-loader and vm-memory dependencies
5200bf3c59666370d1b17d75022c71c57df2523b Cargo: switch vhost_rs to external crate
f190cb05b5964d844296fac6eb903b51ca17dd97 build(deps): bump libc from 0.2.66 to 0.2.67
3447e226d957acc87fb8109d4b53eaa5ef2b5ab7 dependencies: bump vm-memory from `4237db3` to `f3d1c27`
c61104df475fc73f3b2ca5330f7c3bde9b5ad834 vmm: Port to latest vmm-sys-util
0f21781fbee8de884cbd03c68b625484a8dc3b74 cargo: Bump the kvm and vmm-sys-util crates
ca97385da5ebb7989185e2ff8316643c14818d1f build(deps): bump libc from 0.2.65 to 0.2.66
7498647e3f8eed1f011c6e416b1b075cb75fd980 cargo: Update micro_http
587a420429601dd00ec3358811279b9b99689789 cargo: Update to the latest kvm-ioctls version
de9eb3e0fac36e6c9e48d76fe7c813f8cd057090 Bump vmm-sys-utils to 0.2.0
2d7bfdd92010aca3d6ceae815425d34d089a0765 build(deps): bump libc from 0.2.64 to 0.2.65
3bb51d4d5e881e2da1a2f9f5806b08b07ba4b9b1 build(deps): bump libc from 0.2.62 to 0.2.64
14eb071b291f64f86ffb8244f1a4dd43fd11e580 Cargo: Move to crates.io vmm-sys-util
db151819f1a7f60cc8d9bec7b15b4ec2f7e4e6df Cargo.toml: Add workspace config changes
```
Remove two reverted patches:
```
git log --pretty=one vhost_user_backend/ |grep -i "Correct"                                                                          
80c9dc2e0c5cfac8afdf1ffa174f0374f27fe355 Revert "vhost-user-backend: Correct error handling in run"
4a1af7f63c755c54db30b9cc47b2cb86608899ff vhost-user-backend: Correct error handling in run
```
The final source code have no diff with current cloud hypervisor.
The successful cargo build of vhost-user-backend require these two PRs: https://github.com/rust-vmm/vm-virtio/pulls merged into  https://github.com/cloud-hypervisor/vm-virtio ch branch and export next_avail/used in Queue struct as pub in vm-virtio :
```
diff --git a/src/queue.rs b/src/queue.rs
index 280c103..47c736f 100644
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -240,8 +240,8 @@ pub struct Queue {
     /// The maximal size in elements offered by the device
     max_size: u16,

-    next_avail: Wrapping<u16>,
-    next_used: Wrapping<u16>,
+    pub next_avail: Wrapping<u16>,
+    pub next_used: Wrapping<u16>,

     /// The queue size in elements the driver selected
     pub size: u16,
```