### PR TITLE
Switch to using rust-vmm's vhost and vm-virtio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ libc = ">=0.2.39"
 log = ">=0.4.6"
 virtio-bindings = "0.1.0"
 vm-memory = {version = ">=0.2.0", features = ["backend-mmap", "backend-atomic"]}
-vm-virtio = { git = "https://github.com/cloud-hypervisor/vm-virtio", branch = "dragonball" }
+vm-virtio = { git = "https://github.com/rust-vmm/vm-virtio" }
 vmm-sys-util = ">=0.3.1"
-vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }
+vhost_rs = { git = "https://github.com/rust-vmm/vhost", package = "vhost", features = ["vhost-user-slave"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ epoll = ">=4.0.1"
 libc = ">=0.2.39"
 log = ">=0.4.6"
 virtio-bindings = "0.1.0"
-vm-memory = {version = ">=0.2.0", features = ["backend-mmap"]}
+vm-memory = {version = ">=0.2.0", features = ["backend-mmap", "backend-atomic"]}
 vm-virtio = { git = "https://github.com/cloud-hypervisor/vm-virtio", branch = "dragonball" }
 vmm-sys-util = ">=0.3.1"
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -713,7 +713,6 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             .unwrap()
             .queue
             .next_avail = Wrapping(base as u16);
-        self.vrings[index as usize].write().unwrap().queue.next_used = Wrapping(base as u16);
 
         let event_idx: bool = (self.acked_features & (1 << VIRTIO_RING_F_EVENT_IDX)) != 0;
         self.vrings[index as usize]


### PR DESCRIPTION
These commits allows `vhost-user-backend` to switch to rust-vmm's vhost and vm-virtio crates. I've tried to keep the changes at minimal as possible.

There's only one change in the API, which is that the `update_memory` method from the `VhostUserBackend` crate now receives an `GuestMemoryMmap` wrapped within a `GuestMemoryAtomic`.