### PR TITLE
Clamp vm-memory to version 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ epoll = ">=4.0.1"
 libc = ">=0.2.39"
 log = ">=0.4.6"
 virtio-bindings = "0.1.0"
-vm-memory = {version = ">=0.2.0", features = ["backend-mmap", "backend-atomic"]}
+vm-memory = { version = "0.2.2", features = ["backend-mmap", "backend-atomic"] }
 vm-virtio = { git = "https://github.com/rust-vmm/vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 vhost_rs = { git = "https://github.com/rust-vmm/vhost", package = "vhost", features = ["vhost-user-slave"] }


### PR DESCRIPTION
Clamp vm-memory to version 0.2.2. Otherwise, using this crate may
bring both version 0.2.2 and 0.3.0, causing a trait conflict.

Signed-off-by: Sergio Lopez <slp@redhat.com>